### PR TITLE
Add missed D3DKMT_ALIGN64 for output QWord

### DIFF
--- a/src/d3dkmt-wsl.cpp
+++ b/src/d3dkmt-wsl.cpp
@@ -462,7 +462,7 @@ struct D3DDDI_QUERYREGISTRY_INFO_WCHAR16
     D3DDDI_QUERYREGISTRY_STATUS  Status;                 // Out
     union {
         DWORD   OutputDword;                            // Out
-        UINT64  OutputQword;                            // Out
+        D3DKMT_ALIGN64 UINT64  OutputQword;                            // Out
         char16_t   OutputString[1];                     // Out. Dynamic array
         BYTE    OutputBinary[1];                        // Out. Dynamic array
     };


### PR DESCRIPTION
This fixes the registry wchar_t thunks for 32-bit code.