### PR TITLE
d3dkmt-wsl.cpp: Add a couple missing includes

### DIFF
--- a/src/d3dkmt-wsl.cpp
+++ b/src/d3dkmt-wsl.cpp
@@ -14,6 +14,8 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <uchar.h>
+#include <unistd.h>
+#include <cctype>
 #include <cwchar>
 #include <memory>
 #include <algorithm>


### PR DESCRIPTION
Needed for close() and std::tolower()