### PR TITLE
meson: Install libdxg

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -41,7 +41,8 @@ libdxg = library(
   version: '1.0.0',
   include_directories : inc_dirs,
   cpp_args: cppargs,
-  dependencies: [dep_dxheaders])
+  dependencies: [dep_dxheaders],
+  install: true)
 
 dep_libdxg = declare_dependency(
     link_with : libdxg,


### PR DESCRIPTION
Without this, wraps don't work because the library doesn't get
installed along with the thing that wraps it.